### PR TITLE
Fix/remove multiple files concurrently

### DIFF
--- a/src/__tests__/useFileUpload.test.ts
+++ b/src/__tests__/useFileUpload.test.ts
@@ -8,6 +8,10 @@ const file = new File(['foo'], 'foo.txt', {
   type: 'text/plain',
 });
 
+const barFile = new File(['bar'], 'bar.txt', {
+  type: 'text/plain',
+});
+
 const defineProperty = (obj, key, value) => {
   Object.defineProperty(obj, key, { writable: false, value });
 };
@@ -70,6 +74,54 @@ describe('useFileUpload', () => {
     expect(result.current.files).toHaveLength(1);
 
     act(() => result.current.removeFile('foo.txt'));
+
+    expect(result.current.files).toHaveLength(0);
+  });
+
+  /**
+   * Remove multiple files by name concurrently.
+   */
+  it('removes multiple files by name concurrently', () => {
+    const { result } = renderHook(() => useFileUpload());
+    const event = new Event('');
+
+    defineProperty(event, 'currentTarget', { files: [file, barFile] });
+
+    act(() => {
+      result.current.setFiles(event, 'a');
+    });
+
+    expect(result.current.files).toHaveLength(2);
+
+    act(() => {
+      ['foo.txt', 'bar.txt'].forEach((fileName) => {
+        result.current.removeFile(fileName);
+      });
+    });
+
+    expect(result.current.files).toHaveLength(0);
+  });
+
+  /**
+   * Remove multiple files by index concurrently.
+   */
+  it('removes multiple files by index concurrently', () => {
+    const { result } = renderHook(() => useFileUpload());
+    const event = new Event('');
+
+    defineProperty(event, 'currentTarget', { files: [file, barFile] });
+
+    act(() => {
+      result.current.setFiles(event, 'a');
+    });
+
+    expect(result.current.files).toHaveLength(2);
+
+    act(() => {
+      [1, 0].forEach((fileIndex) => {
+        result.current.removeFile(fileIndex);
+      });
+    });
 
     expect(result.current.files).toHaveLength(0);
   });

--- a/src/lib/useFileUpload.ts
+++ b/src/lib/useFileUpload.ts
@@ -88,9 +88,9 @@ export const useFileUpload = (): useFileUploadHook => {
       }
 
       if (typeof file === 'string') {
-        setFilesState(files.filter((_file: File) => _file.name !== file));
+        setFilesState((previousFiles) => previousFiles.filter((_file: File) => _file.name !== file));
       } else {
-        setFilesState(files.filter((_file: File, i) => i !== file));
+        setFilesState((previousFiles) => previousFiles.filter((_file: File, i) => i !== file));
       }
     },
     [files],


### PR DESCRIPTION
### added failing tests for multiple removeFile
I added failing tests to prove it's failing before I submit the fix.
When calling removeFile many times some files are not removed. The use
case is add 2 files and have a button to remove each. These buttons call
removeFile. At the end of the operations we have 1 file listed, instead
of zero.


### fix multiple removeFile calls
The issue was caused by outdated "files" variable. This is due to how
closure works. Each removeFile starts with 2 files in "files". Then when
we remove the file, one file remains. Then when the second removeFile
file is called, one file remains. The solution is using functional
updates, which makes sure we are calculating state over the previous one
instead of some outdated value due to closure.

Reference:

1. https://reactjs.org/docs/hooks-reference.html#functional-updates


