### PR TITLE
feat: improve typing for events

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,7 @@ export type useFileUploadHook = {
   totalSizeInBytes: number;
   clearAllFiles: () => void;
   createFormData: () => FormData;
-  handleDragDropEvent: (e: Event) => void;
+  handleDragDropEvent: (e: React.DragEvent<HTMLElement>) => void;
   removeFile: (file: number | string) => void;
-  setFiles: (e: Event, mode?: 'a' | 'w') => void;
+  setFiles: (e: React.ChangeEvent<HTMLInputElement>, mode?: 'a' | 'w') => void;
 };

--- a/src/lib/useFileUpload.ts
+++ b/src/lib/useFileUpload.ts
@@ -27,7 +27,7 @@ const getTotalSizeInBytes = (files: File[]): number => {
 /**
  * @function handleDragDropEvent
  */
-const handleDragDropEvent = (e: Event) => {
+const handleDragDropEvent = (e: React.DragEvent<HTMLElement>) => {
   e.stopPropagation();
   e.preventDefault();
 };


### PR DESCRIPTION
Currently, events from the input handler needs to be cast as `Event` to pass into `setFiles`. The new changes in types solve this.